### PR TITLE
Test fixes

### DIFF
--- a/scripts/parse_hpoa.py
+++ b/scripts/parse_hpoa.py
@@ -4,7 +4,6 @@ import sys
 import argparse
 import json
 import re
-import ast
 from datetime import datetime
 from dcicutils.ff_utils import (
     get_authentication_with_server,

--- a/scripts/parse_hpoa.py
+++ b/scripts/parse_hpoa.py
@@ -9,8 +9,7 @@ from dcicutils.ff_utils import (
     get_authentication_with_server,
     search_metadata,
 )
-# disabled because there is a re-definition
-# from dcicwrangling.functions.script_utils import convert_key_arg_to_dict
+from dcicwrangling.functions.script_utils import convert_key_arg_to_dict
 
 ''' Dictionary for field mapping between hpoa file and cgap disorder schema
 '''

--- a/scripts/parse_hpoa.py
+++ b/scripts/parse_hpoa.py
@@ -76,15 +76,6 @@ def write_outfile(terms, filename, pretty=False):
             json.dump(terms, outfile)
 
 
-def convert_key_arg_to_dict(key):
-    if all([v in key for v in ['key', 'secret', 'server']]):
-        key = ast.literal_eval(key)
-    if not isinstance(key, dict):
-        print("You included a key argument but it appears to be malformed or missing required info - see --help")
-        sys.exit(1)
-    return key
-
-
 def get_args():  # pragma: no cover
     parser = argparse.ArgumentParser(
         description='Given an HPOA file generate phenotype annotations for that disorder as json',

--- a/scripts/patch_field_for_many_items.py
+++ b/scripts/patch_field_for_many_items.py
@@ -43,7 +43,7 @@ def main():
     elif val == 'False':
         val = False
     if args.isarray:
-        val = val.split("'")
+        val = [v for v in val.split("'") if v]
     ntype = args.numtype
     if ntype:
         if ntype == 'i':

--- a/test/test_generate_wfr_from_pf.py
+++ b/test/test_generate_wfr_from_pf.py
@@ -219,39 +219,38 @@ def test_create_wfr_meta_only_json(auth, prov_workflow, infiles, outfile, wfr_ou
 
 def test_create_wfr_meta_only_json_w_no_wf_uuid(mocker, auth, prov_workflow):
     del prov_workflow['uuid']
-    with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can', return_value=prov_workflow):
-        wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, None, None)
-        assert wfr_json is None
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can', return_value=prov_workflow)
+    wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, None, None)
+    assert wfr_json is None
 
 
 def test_create_wfr_meta_only_json_w_alias_and_desc(mocker, auth, prov_workflow, infiles, outfile):
     alias = 'test_alias'
     desc = 'test description'
-    with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can',
-                      side_effect=[prov_workflow, infiles[0], infiles[1], outfile[0]]):
-        with mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062'):
-            wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, infiles, outfile, alias=alias, description=desc)
-            assert wfr_json['description'] == desc
-            assert wfr_json['aliases'][0] == alias
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can',
+                 side_effect=[prov_workflow, infiles[0], infiles[1], outfile[0]])
+    mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062')
+    wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, infiles, outfile, alias=alias, description=desc)
+    assert wfr_json['description'] == desc
+    assert wfr_json['aliases'][0] == alias
 
 
 def test_create_wfr_meta_only_json_no_in_or_out_files(mocker, auth, prov_workflow):
-    with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can',
-                      return_value=prov_workflow):
-        with mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062'):
-            wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, [], [])
-            assert 'input_files' not in wfr_json
-            assert 'output_files' not in wfr_json
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can', return_value=prov_workflow)
+    mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062')
+    wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, [], [])
+    assert 'input_files' not in wfr_json
+    assert 'output_files' not in wfr_json
 
 
 def test_create_wfr_meta_only_json_no_workflow_args(mocker, auth, prov_workflow, infiles, outfile):
     del prov_workflow['arguments']
-    with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can',
-                      side_effect=[prov_workflow, infiles[0], infiles[1], outfile[0]]):
-        with mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062'):
-            wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, infiles, outfile)
-            assert 'input_files' not in wfr_json
-            assert 'output_files' not in wfr_json
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_if_you_can',
+                 side_effect=[prov_workflow, infiles[0], infiles[1], outfile[0]])
+    mocker.patch('scripts.generate_wfr_from_pf.datetime', return_value='2018-06-11 16:29:22.839062')
+    wfr_json = gw.create_wfr_meta_only_json(auth, prov_workflow, infiles, outfile)
+    assert 'input_files' not in wfr_json
+    assert 'output_files' not in wfr_json
 
 
 def test_wfr_get_args_required_default():
@@ -309,26 +308,21 @@ def mocked_args_dbupd():
 
 def test_wfr_main_no_auth(mocker, capsys, mocked_args_no_args):
     with pytest.raises(SystemExit):
-        with mocker.patch('scripts.generate_wfr_from_pf.get_args',
-                          return_value=mocked_args_no_args):
-            gw.main()
-            out = capsys.readouterr()[0]
-            assert out == "Authentication failed"
+        mocker.patch('scripts.generate_wfr_from_pf.get_args', return_value=mocked_args_no_args)
+        gw.main()
+        out = capsys.readouterr()[0]
+        assert out == "Authentication failed"
 
 
 def test_wfr_main_no_parents(mocker, capsys, mocked_args_dbupd_is_false, auth, prov_workflow,
                              fp_data, infiles, wfr_out_json):
-    with mocker.patch('scripts.generate_wfr_from_pf.get_args',
-                      return_value=mocked_args_dbupd_is_false):
-        with mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args',
-                              return_value=[fp_data['uuid']]):
-                with mocker.patch('scripts.generate_wfr_from_pf.get_metadata',
-                                  side_effect=[prov_workflow, fp_data]):
-                    gw.main()
-                    out = capsys.readouterr()[0]
-                    assert not out
+    mocker.patch('scripts.generate_wfr_from_pf.get_args', return_value=mocked_args_dbupd_is_false)
+    mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args', return_value=[fp_data['uuid']])
+    mocker.patch('scripts.generate_wfr_from_pf.get_metadata', side_effect=[prov_workflow, fp_data])
+    gw.main()
+    out = capsys.readouterr()[0]
+    assert not out
 
 
 def test_wfr_main_dryrun(mocker, capsys, mocked_args_dbupd_is_false, auth, prov_workflow,
@@ -336,38 +330,27 @@ def test_wfr_main_dryrun(mocker, capsys, mocked_args_dbupd_is_false, auth, prov_
     fp_data['produced_from'] = [
         "658ecf64-57a1-41aa-ac04-7224c7ed3208",
         "658ecf64-57a1-41aa-ac04-7224c7ed3209"]
-    with mocker.patch('scripts.generate_wfr_from_pf.get_args',
-                      return_value=mocked_args_dbupd_is_false):
-        with mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args',
-                              return_value=[fp_data['uuid']]):
-                with mocker.patch('scripts.generate_wfr_from_pf.get_metadata',
-                                  side_effect=[prov_workflow, fp_data, infiles[0], infiles[1]]):
-                    with mocker.patch('scripts.generate_wfr_from_pf.create_wfr_meta_only_json',
-                                      return_value=wfr_out_json):
-                        gw.main()
-                        out = capsys.readouterr()[0]
-                        assert out.startswith('DRY RUN -- will post')
+    mocker.patch('scripts.generate_wfr_from_pf.get_args', return_value=mocked_args_dbupd_is_false)
+    mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args', return_value=[fp_data['uuid']])
+    mocker.patch('scripts.generate_wfr_from_pf.get_metadata',
+                 side_effect=[prov_workflow, fp_data, infiles[0], infiles[1]])
+    mocker.patch('scripts.generate_wfr_from_pf.create_wfr_meta_only_json', return_value=wfr_out_json)
+    gw.main()
+    out = capsys.readouterr()[0]
+    assert out.startswith('DRY RUN -- will post')
 
 
-def test_wfr_main_dbupdate(mocker, capsys, mocked_args_dbupd, auth, prov_workflow,
-                           fp_data, infiles, wfr_out_json):
-    fp_data['produced_from'] = [
-        "658ecf64-57a1-41aa-ac04-7224c7ed3208",
-        "658ecf64-57a1-41aa-ac04-7224c7ed3209"]
-    with mocker.patch('scripts.generate_wfr_from_pf.get_args',
-                      return_value=mocked_args_dbupd):
-        with mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args',
-                              return_value=[fp_data['uuid']]):
-                with mocker.patch('scripts.generate_wfr_from_pf.get_metadata',
-                                  side_effect=[prov_workflow, fp_data, infiles[0], infiles[1]]):
-                    with mocker.patch('scripts.generate_wfr_from_pf.create_wfr_meta_only_json',
-                                      return_value=wfr_out_json):
-                        with mocker.patch('scripts.generate_wfr_from_pf.post_metadata',
-                                          return_value='SUCCESS'):
-                            gw.main()
-                            out = capsys.readouterr()[0]
-                            assert out.startswith('SUCCESS')
+def test_wfr_main_dbupdate(mocker, capsys, mocked_args_dbupd, auth,
+                           prov_workflow, fp_data, infiles, wfr_out_json):
+    fp_data['produced_from'] = ["658ecf64-57a1-41aa-ac04-7224c7ed3208", "658ecf64-57a1-41aa-ac04-7224c7ed3209"]
+    mocker.patch('scripts.generate_wfr_from_pf.get_args', return_value=mocked_args_dbupd)
+    mocker.patch('scripts.generate_wfr_from_pf.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.generate_wfr_from_pf.scu.get_item_ids_from_args', return_value=[fp_data['uuid']])
+    mocker.patch('scripts.generate_wfr_from_pf.get_metadata',
+                 side_effect=[prov_workflow, fp_data, infiles[0], infiles[1]])
+    mocker.patch('scripts.generate_wfr_from_pf.create_wfr_meta_only_json', return_value=wfr_out_json)
+    mocker.patch('scripts.generate_wfr_from_pf.post_metadata', return_value='SUCCESS')
+    gw.main()
+    out = capsys.readouterr()[0]
+    assert out.startswith('SUCCESS')

--- a/test/test_geo2fdn.py
+++ b/test/test_geo2fdn.py
@@ -43,9 +43,9 @@ def hidden_sra(mocker):
 
 def test_parse_gsm_with_sra(mocker, srx_file):
     with open(srx_file, 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
-            exp = geo.parse_gsm(gsm)
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
+        exp = geo.parse_gsm(gsm)
     assert exp.link in srx_file
     assert exp.exptype == 'repliseq'
     assert exp.bs == 'SAMN06219555'
@@ -57,9 +57,9 @@ def test_parse_gsm_with_sra(mocker, srx_file):
 
 def test_parse_gsm_dbgap(mocker):
     with open('./test/data_files/SRX3028942.xml', 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2254215.txt')
-            exp = geo.parse_gsm(gsm)
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2254215.txt')
+        exp = geo.parse_gsm(gsm)
     assert exp.bs == 'SAMN05449633'
     assert not exp.layout
     assert exp.instr == 'Illumina HiSeq 2500'
@@ -71,18 +71,17 @@ def test_parse_gsm_dbgap(mocker):
 
 def test_experiment_bad_sra(mocker, capfd):
     with open('./test/data_files/SRX0000000.xml', 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            exp = geo.Experiment('hic', 'Illumina HiSeq 2500', 'GSM1234567',
-                                 'title', 'SAMN05449633', 'SRX0000000')
-            exp.get_sra()
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        exp = geo.Experiment('hic', 'Illumina HiSeq 2500', 'GSM1234567', 'title', 'SAMN05449633', 'SRX0000000')
+        exp.get_sra()
     out, err = capfd.readouterr()
     assert "Couldn't parse" in out
 
 
 def gsm_soft_to_exp_obj(mocker, gsm_file, exp_type=None):
-    with mocker.patch('scripts.geo2fdn.Experiment.get_sra'):
-        gsm = GEOparse.get_GEO(filepath=gsm_file)
-        return geo.parse_gsm(gsm, experiment_type=exp_type)
+    mocker.patch('scripts.geo2fdn.Experiment.get_sra')
+    gsm = GEOparse.get_GEO(filepath=gsm_file)
+    return geo.parse_gsm(gsm, experiment_type=exp_type)
 
 
 def test_parse_gsm_exptypes(mocker):
@@ -95,16 +94,16 @@ def test_parse_gsm_exptypes(mocker):
 
 def test_parse_bs_record(mocker):
     with open('./test/data_files/SAMN06219555.xml', 'r') as samn:
-        with mocker.patch('Bio.Entrez.efetch', return_value=samn):
-            bs = geo.parse_bs_record('SAMN06219555')
+        mocker.patch('Bio.Entrez.efetch', return_value=samn)
+        bs = geo.parse_bs_record('SAMN06219555')
     for item in ['tamoxifen', 'liver', 'NIPBL', 'Nipbl(flox/flox)']:
         assert item in bs.description
 
 
 def test_get_geo_metadata_seq(mocker):
-    with mocker.patch('scripts.geo2fdn.Experiment.get_sra'):
-        with mocker.patch('scripts.geo2fdn.parse_bs_record', return_value='SAMNXXXXXXXX'):
-            gse = geo.get_geo_metadata('./test/data_files/GSE93431_family.soft.gz')
+    mocker.patch('scripts.geo2fdn.Experiment.get_sra')
+    mocker.patch('scripts.geo2fdn.parse_bs_record', return_value='SAMNXXXXXXXX')
+    gse = geo.get_geo_metadata('./test/data_files/GSE93431_family.soft.gz')
     assert len([exp for exp in gse.experiments if exp.exptype == 'hic']) == 6
     assert len([exp for exp in gse.experiments if exp.exptype == 'chipseq']) == 14
     assert len([exp for exp in gse.experiments if exp.exptype == 'rnaseq']) == 12
@@ -127,9 +126,9 @@ def test_get_geo_metadata_bad_accession(capfd):
 
 def test_get_geo_metadata_sra_hidden(capfd, mocker, hidden_sra):
     gse_all = GEOparse.get_GEO(filepath='./test/data_files/GSE93431_family.soft.gz')
-    with mocker.patch('scripts.geo2fdn.parse_bs_record', return_value='SAMNXXXXXXXX'):
-        with mocker.patch('scripts.geo2fdn.parse_gsm', return_value=hidden_sra):
-            gse = geo.get_geo_metadata('./test/data_files/GSE93431_family.soft.gz')
+    mocker.patch('scripts.geo2fdn.parse_bs_record', return_value='SAMNXXXXXXXX')
+    mocker.patch('scripts.geo2fdn.parse_gsm', return_value=hidden_sra)
+    gse = geo.get_geo_metadata('./test/data_files/GSE93431_family.soft.gz')
     out, err = capfd.readouterr()
     assert not gse
     assert len(gse_all.gsms.values()) > 10

--- a/test/test_geo2fdn.py
+++ b/test/test_geo2fdn.py
@@ -13,32 +13,32 @@ def srx_file():
 @pytest.fixture
 def bs_obj(mocker):
     with open('./test/data_files/SAMN06219555.xml', 'r') as samn:
-        with mocker.patch('Bio.Entrez.efetch', return_value=samn):
-            return geo.parse_bs_record('SAMN06219555')
+        mocker.patch('Bio.Entrez.efetch', return_value=samn)
+        return geo.parse_bs_record('SAMN06219555')
 
 
 @pytest.fixture
 def exp_with_sra(mocker, srx_file):
     with open(srx_file, 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
-            return geo.parse_gsm(gsm)
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
+        return geo.parse_gsm(gsm)
 
 
 @pytest.fixture
 def exp_with_sra_pe(mocker):
     with open('./test/data_files/SRX1839065.xml', 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2198225.txt')
-            return geo.parse_gsm(gsm)
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2198225.txt')
+        return geo.parse_gsm(gsm)
 
 
 @pytest.fixture
 def hidden_sra(mocker):
     with open('./test/data_files/SRX4191023.xml', 'r') as srx:
-        with mocker.patch('Bio.Entrez.efetch', return_value=srx):
-            gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
-            return geo.parse_gsm(gsm)
+        mocker.patch('Bio.Entrez.efetch', return_value=srx)
+        gsm = GEOparse.get_GEO(filepath='./test/data_files/GSM2715320.txt')
+        return geo.parse_gsm(gsm)
 
 
 def test_parse_gsm_with_sra(mocker, srx_file):

--- a/test/test_patch_field_for_many_items.py
+++ b/test/test_patch_field_for_many_items.py
@@ -111,78 +111,64 @@ def mocked_args_w_delete():
 
 def test_pffmi_main_no_auth(mocker, capsys, mocked_args_no_args):
     with pytest.raises(SystemExit):
-        with mocker.patch('scripts.patch_field_for_many_items.get_args',
-                          return_value=mocked_args_no_args):
-            pf.main()
-            out = capsys.readouterr()[0]
-            assert out == "Authentication failed"
+        mocker.patch('scripts.patch_field_for_many_items.get_args',
+                     return_value=mocked_args_no_args)
+        pf.main()
+        out = capsys.readouterr()[0]
+        assert out == "Authentication failed"
 
 
 def test_pffmi_main_dryrun(mocker, capsys, mocked_args_dbupd_is_false, auth):
     iids = ['id1', 'id2']
-    with mocker.patch('scripts.patch_field_for_many_items.get_args',
-                      return_value=mocked_args_dbupd_is_false):
-        with mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args',
-                              return_value=iids):
-                pf.main()
-                out = capsys.readouterr()[0]
-                for i in iids:
-                    s = "PATCHING %s to status = deleted" % i
-                    assert s in out
+    mocker.patch('scripts.patch_field_for_many_items.get_args', return_value=mocked_args_dbupd_is_false)
+    mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args', return_value=iids)
+    pf.main()
+    out = capsys.readouterr()[0]
+    for i in iids:
+        s = "PATCHING %s to status = deleted" % i
+        assert s in out
 
 
 def test_pffmi_main_val_is_array(mocker, capsys, mocked_args_is_array, auth):
     iids = ['id1', 'id2']
-    with mocker.patch('scripts.patch_field_for_many_items.get_args',
-                      return_value=mocked_args_is_array):
-        with mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args',
-                              return_value=iids):
-                pf.main()
-                out = capsys.readouterr()[0]
-                for i in iids:
-                    s = "PATCHING %s to aliases = ['4dn-dcic-lab:test']" % i
-                    assert s in out
+    mocker.patch('scripts.patch_field_for_many_items.get_args', return_value=mocked_args_is_array)
+    mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args', return_value=iids)
+    pf.main()
+    out = capsys.readouterr()[0]
+    for i in iids:
+        s = "PATCHING %s to aliases = ['4dn-dcic-lab:test']" % i
+        assert s in out
 
 
 def test_pffmi_main_dbupdate(mocker, capsys, mocked_args_dbupd_is_true, auth):
     iids = ['id1', 'id2']
     resp1 = {'status': 'success'}
     resp2 = {'status': 'error', 'description': "access denied"}
-    with mocker.patch('scripts.patch_field_for_many_items.get_args',
-                      return_value=mocked_args_dbupd_is_true):
-        with mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args',
-                              return_value=iids):
-                with mocker.patch('scripts.patch_field_for_many_items.patch_metadata',
-                                  side_effect=[resp1, resp2]):
-                    pf.main()
-                    out = capsys.readouterr()[0]
-                    s1 = "PATCHING %s to status = deleted" % iids[0]
-                    s2 = "FAILED TO PATCH %s RESPONSE STATUS error access denied" % iids[1]
-                    assert s1 in out
-                    assert s2 in out
-                    assert 'SUCCESS' in out
+    mocker.patch('scripts.patch_field_for_many_items.get_args', return_value=mocked_args_dbupd_is_true)
+    mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args', return_value=iids)
+    mocker.patch('scripts.patch_field_for_many_items.patch_metadata', side_effect=[resp1, resp2])
+    pf.main()
+    out = capsys.readouterr()[0]
+    s1 = "PATCHING %s to status = deleted" % iids[0]
+    s2 = "FAILED TO PATCH %s RESPONSE STATUS error access denied" % iids[1]
+    assert s1 in out
+    assert s2 in out
+    assert 'SUCCESS' in out
 
 
 def test_pffmi_main_dbupdate_delete(mocker, capsys, mocked_args_w_delete, auth):
     iids = ['id1', 'id2']
     resp1 = {'status': 'success'}
-    with mocker.patch('scripts.patch_field_for_many_items.get_args',
-                      return_value=mocked_args_w_delete):
-        with mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server',
-                          return_value=auth):
-            with mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args',
-                              return_value=iids):
-                with mocker.patch('scripts.patch_field_for_many_items.delete_field',
-                                  side_effect=[resp1, resp1]):
-                    pf.main()
-                    out = capsys.readouterr()[0]
-                    for i in iids:
-                        s = "PATCHING %s to aliases = *delete*" % i
-                        assert s in out
-                        assert 'SUCCESS' in out
+    mocker.patch('scripts.patch_field_for_many_items.get_args', return_value=mocked_args_w_delete)
+    mocker.patch('scripts.patch_field_for_many_items.get_authentication_with_server', return_value=auth)
+    mocker.patch('scripts.patch_field_for_many_items.scu.get_item_ids_from_args', return_value=iids)
+    mocker.patch('scripts.patch_field_for_many_items.delete_field', side_effect=[resp1, resp1])
+    pf.main()
+    out = capsys.readouterr()[0]
+    for i in iids:
+        s = "PATCHING %s to aliases = *delete*" % i
+        assert s in out
+        assert 'SUCCESS' in out

--- a/test/test_rxiv2ja.py
+++ b/test/test_rxiv2ja.py
@@ -64,7 +64,7 @@ def test_remove_skipped_vals_w_item_lookup(mocker):
     side_effect = ['uuid1', 'uuid2', 'uuid1']
     val = ['id1', 'id2']
     vals2skip = ['id1']
-    mocker.patch('functions.script_utils.get_item_uuid', side_effect=side_effect):
+    mocker.patch('functions.script_utils.get_item_uuid', side_effect=side_effect)
     result = rj.remove_skipped_vals(val, vals2skip)
     assert result[0] == val[1]
 

--- a/test/test_rxiv2ja.py
+++ b/test/test_rxiv2ja.py
@@ -55,33 +55,27 @@ def test_remove_skipped_vals_w_good_atids(mocker):
     side_effect = ['uuid1', 'uuid2', 'uuid1', 'uuid2', 'uuid3']
     val = ['id1', 'id2']
     vals2skip = ['id1', 'id2', 'id3']
-    # import pdb; pdb.set_trace()
-    with mocker.patch('functions.script_utils.get_item_uuid',
-                      side_effect=side_effect):
-        result = rj.remove_skipped_vals(val, vals2skip)
-        assert not result
+    mocker.patch('functions.script_utils.get_item_uuid', side_effect=side_effect)
+    result = rj.remove_skipped_vals(val, vals2skip)
+    assert not result
 
 
 def test_remove_skipped_vals_w_item_lookup(mocker):
     side_effect = ['uuid1', 'uuid2', 'uuid1']
     val = ['id1', 'id2']
     vals2skip = ['id1']
-    # import pdb; pdb.set_trace()
-    with mocker.patch('functions.script_utils.get_item_uuid',
-                      side_effect=side_effect):
-        result = rj.remove_skipped_vals(val, vals2skip)
-        assert result[0] == val[1]
+    mocker.patch('functions.script_utils.get_item_uuid', side_effect=side_effect):
+    result = rj.remove_skipped_vals(val, vals2skip)
+    assert result[0] == val[1]
 
 
 def test_remove_skipped_vals_w_item_lookup_and_not_found(mocker):
     side_effect = ['uuid1', None, 'uuid3', 'uuid1', None]
     val = ['id1', 'id2', 'id3']
     vals2skip = ['id3', 'id4']
-    # import pdb; pdb.set_trace()
-    with mocker.patch('functions.script_utils.get_item_uuid',
-                      side_effect=side_effect):
-        result = rj.remove_skipped_vals(val, vals2skip)
-        assert result[0] == val[0]
+    mocker.patch('functions.script_utils.get_item_uuid', side_effect=side_effect)
+    result = rj.remove_skipped_vals(val, vals2skip)
+    assert result[0] == val[0]
 
 
 @pytest.fixture
@@ -224,54 +218,54 @@ def test_patch_and_report_w_skipped_no_patch(capsys, auth):
 
 
 def test_patch_and_report_w_patch(capsys, mocker, auth, pdict):
-    with mocker.patch('scripts.rxiv2ja.patch_metadata', return_value={'status': 'success'}):
-        result = rj.patch_and_report(auth, pdict, None, 'test_uuid', False)
-        out = capsys.readouterr()[0]
-        assert 'PATCHING - test_uuid' in out
-        for k, v in pdict.items():
-            s = '%s \t %s' % (k, v)
-            assert s in out
-        assert 'SUCCESS!' in out
-        assert result is True
+    mocker.patch('scripts.rxiv2ja.patch_metadata', return_value={'status': 'success'})
+    result = rj.patch_and_report(auth, pdict, None, 'test_uuid', False)
+    out = capsys.readouterr()[0]
+    assert 'PATCHING - test_uuid' in out
+    for k, v in pdict.items():
+        s = '%s \t %s' % (k, v)
+        assert s in out
+    assert 'SUCCESS!' in out
+    assert result is True
 
 
 def test_patch_and_report_w_fail(capsys, mocker, auth, pdict):
-    with mocker.patch('scripts.rxiv2ja.patch_metadata', return_value={'status': 'error', 'description': 'woopsie'}):
-        result = rj.patch_and_report(auth, pdict, None, 'test_uuid', False)
-        out = capsys.readouterr()[0]
-        assert 'PATCHING - test_uuid' in out
-        for k, v in pdict.items():
-            s = '%s \t %s' % (k, v)
-            assert s in out
-        assert 'FAILED TO PATCH' in out
-        assert 'woopsie' in out
-        assert not result
+    mocker.patch('scripts.rxiv2ja.patch_metadata', return_value={'status': 'error', 'description': 'woopsie'})
+    result = rj.patch_and_report(auth, pdict, None, 'test_uuid', False)
+    out = capsys.readouterr()[0]
+    assert 'PATCHING - test_uuid' in out
+    for k, v in pdict.items():
+        s = '%s \t %s' % (k, v)
+        assert s in out
+    assert 'FAILED TO PATCH' in out
+    assert 'woopsie' in out
+    assert not result
 
 
 def test_find_and_patch_item_references_no_refs(capsys, mocker, auth):
     old_uuid = 'old_uuid'
     new_uuid = 'new_uuid'
     output = "No references to %s found." % old_uuid
-    with mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=[]):
-        result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
-        out = capsys.readouterr()[0]
-        assert output in out
-        assert result is True
+    mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=[])
+    result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
+    out = capsys.readouterr()[0]
+    assert output in out
+    assert result is True
 
 
 def test_find_and_patch_item_references_w_refs(mocker, auth):
     old_uuid = 'old_uuid'
     new_uuid = 'new_uuid'
-    with mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=['bs_uuid', 'ex_uuid']):
-        with mocker.patch('scripts.rxiv2ja.patch_and_report', side_effect=[True, True]):
-            result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
-            assert result is True
+    mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=['bs_uuid', 'ex_uuid'])
+    mocker.patch('scripts.rxiv2ja.patch_and_report', side_effect=[True, True])
+    result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
+    assert result is True
 
 
 def test_find_and_patch_item_references_w_refs_one_fail(mocker, auth):
     old_uuid = 'old_uuid'
     new_uuid = 'new_uuid'
-    with mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=['bs_uuid', 'ex_uuid1', 'ex_uuid2']):
-        with mocker.patch('scripts.rxiv2ja.patch_and_report', side_effect=[True, False, True]):
-            result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
-            assert not result
+    mocker.patch('scripts.rxiv2ja.scu.get_item_ids_from_args', return_value=['bs_uuid', 'ex_uuid1', 'ex_uuid2'])
+    mocker.patch('scripts.rxiv2ja.patch_and_report', side_effect=[True, False, True])
+    result = rj.find_and_patch_item_references(auth, old_uuid, new_uuid, False)
+    assert not result

--- a/test/test_script_utils.py
+++ b/test/test_script_utils.py
@@ -178,10 +178,10 @@ def test_has_field_value_value_not_found_as_string(eset_json):
 
 def test_get_types_that_can_have_field(mocker, profiles):
     field = 'tags'
-    with mocker.patch('functions.script_utils.get_metadata', return_value=profiles):
-        types_w_field = scu.get_types_that_can_have_field('conn', field)
-        assert 'ExperimentSetReplicate' in types_w_field
-        assert 'TreatmentChemical' not in types_w_field
+    mocker.patch('functions.script_utils.get_metadata', return_value=profiles)
+    types_w_field = scu.get_types_that_can_have_field('conn', field)
+    assert 'ExperimentSetReplicate' in types_w_field
+    assert 'TreatmentChemical' not in types_w_field
 
 
 def test_get_item_type_from_dict(eset_json):
@@ -191,17 +191,17 @@ def test_get_item_type_from_dict(eset_json):
 
 
 def test_get_item_type_from_id(mocker, auth):
-    with mocker.patch('functions.script_utils.get_metadata', return_value={'@type': ['ExperimentSetReplicate']}):
-        result = scu.get_item_type(auth, 'blah')
-        assert result == 'ExperimentSetReplicate'
+    mocker.patch('functions.script_utils.get_metadata', return_value={'@type': ['ExperimentSetReplicate']})
+    result = scu.get_item_type(auth, 'blah')
+    assert result == 'ExperimentSetReplicate'
 
 
 def test_get_item_type_no_type(mocker, auth, capsys):
-    with mocker.patch('functions.script_utils.get_metadata', return_value={'description': 'blah'}):
-        result = scu.get_item_type(auth, 'blah')
-        out = capsys.readouterr()[0]
-        assert out == "Can't find a type for item blah\n"
-        assert result is None
+    mocker.patch('functions.script_utils.get_metadata', return_value={'description': 'blah'})
+    result = scu.get_item_type(auth, 'blah')
+    out = capsys.readouterr()[0]
+    assert out == "Can't find a type for item blah\n"
+    assert result is None
 
 
 @pytest.fixture
@@ -222,11 +222,11 @@ def test_get_item_ids_from_list(auth):
 
 def test_get_item_ids_from_search(mocker, auth, items_w_uuids):
     ids = ['a', 'b', 'c']
-    with mocker.patch('functions.script_utils.search_metadata', return_value=[]):
-        with mocker.patch('functions.script_utils.get_metadata', return_value=items_w_uuids):
-            result = scu.get_item_ids_from_args('search', auth, True)
-            for a in [i in ids for i in result]:
-                assert a
+    mocker.patch('functions.script_utils.search_metadata', return_value=[])
+    mocker.patch('functions.script_utils.get_metadata', return_value=items_w_uuids)
+    result = scu.get_item_ids_from_args('search', auth, True)
+    for a in [i in ids for i in result]:
+        assert a
 
 
 def test_get_item_uuid_w_uuid(auth):
@@ -237,20 +237,18 @@ def test_get_item_uuid_w_uuid(auth):
 
 def test_get_item_uuid_w_atid(mocker, auth):
     atid = '/labs/test-lab'
-    with mocker.patch('functions.script_utils.get_metadata',
-                      return_value={'uuid': 'test_uuid'}) as mt:
-        result = scu.get_item_uuid(atid, auth)
-        assert mt.called_with(atid, auth)
-        assert result == 'test_uuid'
+    mt = mocker.patch('functions.script_utils.get_metadata', return_value={'uuid': 'test_uuid'})
+    result = scu.get_item_uuid(atid, auth)
+    assert mt.called_with(atid, auth)
+    assert result == 'test_uuid'
 
 
 def test_get_item_uuid_not_found(mocker, auth):
     atid = '/labs/non-lab'
-    with mocker.patch('functions.script_utils.get_metadata',
-                      return_value={'status': 'error'}) as mt:
-        result = scu.get_item_uuid(atid, auth)
-        assert mt.called_with(atid, auth)
-        assert result is None
+    mt = mocker.patch('functions.script_utils.get_metadata', return_value={'status': 'error'})
+    result = scu.get_item_uuid(atid, auth)
+    assert mt.called_with(atid, auth)
+    assert result is None
 
 
 def test_create_ff_arg_parser(capsys):
@@ -295,25 +293,23 @@ def test_get_linked_items_w_item_in_found(auth):
 
 
 def test_get_linked_items_w_error_status(auth, mocker):
-    with mocker.patch('functions.script_utils.get_metadata', return_value={'status': 'error'}):
-        iids = scu.get_linked_items(auth, 'test_id')
-        assert not iids
+    mocker.patch('functions.script_utils.get_metadata', return_value={'status': 'error'})
+    iids = scu.get_linked_items(auth, 'test_id')
+    assert not iids
 
 
 def test_get_linked_items_w_no_type(auth, mocker):
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[{'status': 'released'},
-                                   {'field': 'value'}]):
-        iids = scu.get_linked_items(auth, 'test_id')
-        assert not iids
+    mocker.patch('functions.script_utils.get_metadata',
+                 side_effect=[{'status': 'released'}, {'field': 'value'}])
+    iids = scu.get_linked_items(auth, 'test_id')
+    assert not iids
 
 
 def test_get_linked_items_w_type_in_no_children(auth, mocker):
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[{'status': 'current'},
-                                   {'@type': ['Publication']}]):
-        iids = scu.get_linked_items(auth, 'test_id')
-        assert iids['test_id'] == 'Publication'
+    mocker.patch('functions.script_utils.get_metadata',
+                 side_effect=[{'status': 'current'}, {'@type': ['Publication']}])
+    iids = scu.get_linked_items(auth, 'test_id')
+    assert iids['test_id'] == 'Publication'
 
 
 def test_get_linked_items_w_linked_items(auth, mocker):
@@ -326,15 +322,12 @@ def test_get_linked_items_w_linked_items(auth, mocker):
         'attachment': '6256801c-9c6e-4563-a97a-a295fccf5f07'
     }
     found = {'7256801c-9c6e-4563-a97a-a295fccf5f07': 'Biosource'}
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[resp1,
-                                   {'@type': ['Biosample']}]):
-        with mocker.patch('functions.script_utils.find_uuids',
-                          return_value=['7256801c-9c6e-4563-a97a-a295fccf5f07']):
-            iids = scu.get_linked_items(auth, 'test_id', found)
-            for i in iids:
-                assert i in goodids
-                assert i not in badids
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[resp1, {'@type': ['Biosample']}])
+    mocker.patch('functions.script_utils.find_uuids', return_value=['7256801c-9c6e-4563-a97a-a295fccf5f07'])
+    iids = scu.get_linked_items(auth, 'test_id', found)
+    for i in iids:
+        assert i in goodids
+        assert i not in badids
 
 
 def test_get_linked_items_w_no_linked_foundids(auth, mocker):
@@ -347,15 +340,12 @@ def test_get_linked_items_w_no_linked_foundids(auth, mocker):
         'attachment': '6256801c-9c6e-4563-a97a-a295fccf5f07'
     }
     found = {}
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[resp1,
-                                   {'@type': ['Biosample']}]):
-        with mocker.patch('functions.script_utils.find_uuids',
-                          return_value=None):
-            iids = scu.get_linked_items(auth, 'test_id', found)
-            for i in iids:
-                assert i in goodids
-                assert i not in badids
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[resp1, {'@type': ['Biosample']}])
+    mocker.patch('functions.script_utils.find_uuids', return_value=None)
+    iids = scu.get_linked_items(auth, 'test_id', found)
+    for i in iids:
+        assert i in goodids
+        assert i not in badids
 
 
 def test_get_linked_item_ids_w_recursive(auth, mocker):
@@ -377,25 +367,24 @@ def test_get_linked_item_ids_w_recursive(auth, mocker):
     resp3 = {
         'status': 'released',
     }
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[resp1,
-                                   {'@type': ['Biosample']},
-                                   resp2,
-                                   {'@type': ['Biosource']},
-                                   resp3,
-                                   {'@type': ['Vendor']}]):
-        with mocker.patch('functions.script_utils.find_uuids',
-                          side_effect=[None,
-                                       ['7256801c-9c6e-4563-a97a-a295fccf5f07'],
-                                       None,
-                                       None,
-                                       ['5256801c-9c6e-4563-a97a-a295fccf5f07'],
-                                       None,
-                                       None]):
-            iids = scu.get_linked_items(auth, 'test_id')
-            for i in iids:
-                assert i in goodids
-                assert i not in badids
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[
+        resp1, {'@type': ['Biosample']},
+        resp2, {'@type': ['Biosource']},
+        resp3, {'@type': ['Vendor']}
+    ])
+    mocker.patch('functions.script_utils.find_uuids', side_effect=[
+        None,
+        ['7256801c-9c6e-4563-a97a-a295fccf5f07'],
+        None,
+        None,
+        ['5256801c-9c6e-4563-a97a-a295fccf5f07'],
+        None,
+        None
+    ])
+    iids = scu.get_linked_items(auth, 'test_id')
+    for i in iids:
+        assert i in goodids
+        assert i not in badids
 
 
 @pytest.fixture
@@ -416,27 +405,24 @@ def test_get_item_if_you_can_json_w_uuid(auth, eset_json):
 
 
 def test_get_item_if_you_can_w_uuid(mocker, auth, eset_json):
-    with mocker.patch('functions.script_utils.get_metadata', return_value=eset_json):
-        result = scu.get_item_if_you_can(auth, eset_json['uuid'])
-        assert result == eset_json
+    mocker.patch('functions.script_utils.get_metadata', return_value=eset_json)
+    result = scu.get_item_if_you_can(auth, eset_json['uuid'])
+    assert result == eset_json
 
 
 def test_get_item_if_you_can_w_termname_and_itype(mocker, auth, cell_line_json):
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[None, cell_line_json]):
-        result = scu.get_item_if_you_can(auth, cell_line_json['term_name'], 'OntologyTerm')
-        assert result == cell_line_json
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[None, cell_line_json])
+    result = scu.get_item_if_you_can(auth, cell_line_json['term_name'], 'OntologyTerm')
+    assert result == cell_line_json
 
 
 def test_get_item_if_you_can_w_termname_and_no_itype_no_item(mocker, auth, cell_line_json):
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[None, None]):
-        result = scu.get_item_if_you_can(auth, cell_line_json['term_name'])
-        assert result is None
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[None, None])
+    result = scu.get_item_if_you_can(auth, cell_line_json['term_name'])
+    assert result is None
 
 
 def test_get_item_if_you_can_w_fakename_and_itype_no_item(mocker, auth):
-    with mocker.patch('functions.script_utils.get_metadata',
-                      side_effect=[None, None]):
-        result = scu.get_item_if_you_can(auth, 'fake name', 'OntologyTerm')
-        assert result is None
+    mocker.patch('functions.script_utils.get_metadata', side_effect=[None, None])
+    result = scu.get_item_if_you_can(auth, 'fake name', 'OntologyTerm')
+    assert result is None

--- a/test/test_tag_release_freeze.py
+++ b/test/test_tag_release_freeze.py
@@ -33,28 +33,28 @@ def test_get_attype_w_no_attype():
 def test_make_tag_patch_already_has_tag(mocker):
     tag = 'test_tag'
     item = {'uuid': 'test_uuid', 'tags': [tag]}
-    with mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=True):
-        result = trf.make_tag_patch(item, tag)
-        assert result is None
+    mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=True)
+    result = trf.make_tag_patch(item, tag)
+    assert result is None
 
 
 def test_make_tag_patch_no_existing_tags(mocker):
     tag = 'test_tag'
     item = {'uuid': 'test_uuid'}
-    with mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=False):
-        result = trf.make_tag_patch(item, tag)
-        assert len(result['tags']) == 1
-        assert tag in result['tags']
+    mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=False)
+    result = trf.make_tag_patch(item, tag)
+    assert len(result['tags']) == 1
+    assert tag in result['tags']
 
 
 def test_make_tag_patch_w_existing_tags(mocker):
     tag = 'test_tag'
     item = {'uuid': 'test_uuid', 'tags': ['old_tag']}
-    with mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=False):
-        result = trf.make_tag_patch(item, tag)
-        assert len(result['tags']) == 2
-        assert tag in result['tags']
-        assert 'old_tag' in result['tags']
+    mocker.patch('scripts.tag_release_freeze.scu.has_field_value', return_value=False)
+    result = trf.make_tag_patch(item, tag)
+    assert len(result['tags']) == 2
+    assert tag in result['tags']
+    assert 'old_tag' in result['tags']
 
 
 def test_do_patch_dry_run(capsys, auth):
@@ -71,11 +71,11 @@ def test_do_patch_success(capsys, mocker, auth):
     input = ['test_uuid', 'Item', {'tags': ['test_tag']}]
     output = 'UPDATING - %s of type %s with %s\nsuccess\n' % tuple(input)
     cnts = Counter()
-    with mocker.patch('scripts.tag_release_freeze.patch_metadata', return_value={'status': 'success'}):
-        trf.do_patch(*input, auth, True, cnts)
-        out = capsys.readouterr()[0]
-        assert out == output
-        assert cnts['patched'] == 1
+    mocker.patch('scripts.tag_release_freeze.patch_metadata', return_value={'status': 'success'})
+    trf.do_patch(*input, auth, True, cnts)
+    out = capsys.readouterr()[0]
+    assert out == output
+    assert cnts['patched'] == 1
 
 
 def test_do_patch_failure(capsys, mocker, auth):
@@ -83,60 +83,60 @@ def test_do_patch_failure(capsys, mocker, auth):
     err = {'status': 'error'}
     output = 'UPDATING - %s of type %s with %s\n%s\n%s\n' % tuple(input + [err['status'], str(err)])
     cnts = Counter()
-    with mocker.patch('scripts.tag_release_freeze.patch_metadata', return_value=err):
-        trf.do_patch(*input, auth, True, cnts)
-        out = capsys.readouterr()[0]
-        assert out == output
-        assert cnts['errors'] == 1
+    mocker.patch('scripts.tag_release_freeze.patch_metadata', return_value=err)
+    trf.do_patch(*input, auth, True, cnts)
+    out = capsys.readouterr()[0]
+    assert out == output
+    assert cnts['errors'] == 1
 
 
 def test_add_tag2item_no_uid(capsys, mocker, auth):
-    with mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released'}):
-        trf.add_tag2item(auth, 'iid', 'test_tag', [], Counter())
-        out = capsys.readouterr()[0]
-        assert "SEEN OR IDLESS ITEM - SKIPPING" in out
+    mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released'})
+    trf.add_tag2item(auth, 'iid', 'test_tag', [], Counter())
+    out = capsys.readouterr()[0]
+    assert "SEEN OR IDLESS ITEM - SKIPPING" in out
 
 
 def test_add_tag2item_in_seen(capsys, mocker, auth):
-    with mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'}):
-        trf.add_tag2item(auth, 'iid', 'test_tag', ['test_uuid'], Counter())
-        out = capsys.readouterr()[0]
-        assert "SEEN OR IDLESS ITEM - SKIPPING" in out
+    mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'})
+    trf.add_tag2item(auth, 'iid', 'test_tag', ['test_uuid'], Counter())
+    out = capsys.readouterr()[0]
+    assert "SEEN OR IDLESS ITEM - SKIPPING" in out
 
 
 def test_add_tag2item_add_the_tag(mocker, auth):
     seen = []
     cnts = Counter()
-    with mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'}):
-        with mocker.patch('scripts.tag_release_freeze.has_released', return_value=True):
-            with mocker.patch('scripts.tag_release_freeze.get_attype', return_value=None):
-                with mocker.patch('scripts.tag_release_freeze.make_tag_patch', return_value={'tags': ['test_tag']}):
-                    with mocker.patch('scripts.tag_release_freeze.do_patch'):
-                        trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
-                        assert 'test_uuid' in seen
+    mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'})
+    mocker.patch('scripts.tag_release_freeze.has_released', return_value=True)
+    mocker.patch('scripts.tag_release_freeze.get_attype', return_value=None)
+    mocker.patch('scripts.tag_release_freeze.make_tag_patch', return_value={'tags': ['test_tag']})
+    mocker.patch('scripts.tag_release_freeze.do_patch')
+    trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
+    assert 'test_uuid' in seen
 
 
 def test_add_tag2item_no_patch(capsys, mocker, auth):
     seen = []
     cnts = Counter()
-    with mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'}):
-        with mocker.patch('scripts.tag_release_freeze.has_released', return_value=True):
-            with mocker.patch('scripts.tag_release_freeze.get_attype', return_value=None):
-                with mocker.patch('scripts.tag_release_freeze.make_tag_patch', return_value=None):
-                    trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
-                    out = capsys.readouterr()[0]
-                    assert out == 'NOTHING TO PATCH - skipping test_uuid\n'
-                    assert cnts['skipped'] == 1
-                    assert 'test_uuid' in seen
+    mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'released', 'uuid': 'test_uuid'})
+    mocker.patch('scripts.tag_release_freeze.has_released', return_value=True)
+    mocker.patch('scripts.tag_release_freeze.get_attype', return_value=None)
+    mocker.patch('scripts.tag_release_freeze.make_tag_patch', return_value=None)
+    trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
+    out = capsys.readouterr()[0]
+    assert out == 'NOTHING TO PATCH - skipping test_uuid\n'
+    assert cnts['skipped'] == 1
+    assert 'test_uuid' in seen
 
 
 def test_add_tag2item_not_released(capsys, mocker, auth):
     seen = []
     cnts = Counter()
-    with mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'deleted', 'uuid': 'test_uuid'}):
-        with mocker.patch('scripts.tag_release_freeze.has_released', return_value=False):
-            trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
-            out = capsys.readouterr()[0]
-            assert out == "STATUS deleted doesn't get tagged - skipping test_uuid\n"
-            assert cnts['skipped'] == 1
-            assert 'test_uuid' in seen
+    mocker.patch('scripts.tag_release_freeze.get_metadata', return_value={'status': 'deleted', 'uuid': 'test_uuid'})
+    mocker.patch('scripts.tag_release_freeze.has_released', return_value=False)
+    trf.add_tag2item(auth, 'iid', 'test_tag', seen, cnts, 'Biosample', True)
+    out = capsys.readouterr()[0]
+    assert out == "STATUS deleted doesn't get tagged - skipping test_uuid\n"
+    assert cnts['skipped'] == 1
+    assert 'test_uuid' in seen


### PR DESCRIPTION
Newest version of pytest-mock throws errors/fails test when mocker.patch is used as a context manager. I fixed all the tests by changing `with mocker.patch(arg1, arg2):` to `mocker.patch(arg1, arg2)`. `with mocker.patch(arg1, arg2) as x:` can also be changed to `x = mocker.patch(arg1, arg2)`. I think the original unittest.mock needed decorators and context managers, but pytest.mock does not. Additionally, I think the reason why this didn't happen in our other repos is because this one uses the latest version of pytest-mock but the others do not. 
- edited all lines in tests containing `with mocker.patch`
- edited a line in patch_field_for_many_items.py to get rid of empty values in a list