### PR TITLE
check fastqc only for fastq files

### DIFF
--- a/notebooks/useful_notebooks/01_find_and_release.ipynb
+++ b/notebooks/useful_notebooks/01_find_and_release.ipynb
@@ -243,7 +243,7 @@
     "\n",
     "print('\\nFILE FASTQ CHECK')\n",
     "for a_file in store.get('file_fastq', []):\n",
-    "    if not a_file.get('quality_metric'):\n",
+    "    if not a_file.get('quality_metric') and a_file['file_format']['display_title'] == 'fastq':\n",
     "        print(a_file['accession'], 'missing fastqc')\n",
     "    if not a_file.get('content_md5sum'):\n",
     "        print(a_file['accession'], 'missing content md5 sum')\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicwrangling"
-version = "0.5.2"
+version = "0.5.3"
 description = "Scripts and Jupyter notebooks for 4DN wrangling"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
FileFastq items now can have different `file_format`, but only fastq require fastQC.