### PR TITLE
released to lab is level 8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ dcicwrangling
 Change Log
 ----------
 
+1.2.1
+=====
+
+* Fix a bug in status level for UserContent items.
+
+
 1.2.0
 =====
 

--- a/notebooks/useful_notebooks/01_find_and_release.ipynb
+++ b/notebooks/useful_notebooks/01_find_and_release.ipynb
@@ -39,7 +39,7 @@
     "    \"in review by lab\": 4,\n",
     "    \"revoked\": 0, \"archived\": 0,\"deleted\": 0, \"obsolete\": 0, \"replaced\": 0, \"archived to project\": 0,\n",
     "    # additional file statuses\n",
-    "    'to be uploaded by workflow': 4, 'uploading': 4, 'uploaded': 4, 'upload failed': 4, 'draft': 4, 'released to lab': 4}\n",
+    "    'to be uploaded by workflow': 4, 'uploading': 4, 'uploaded': 4, 'upload failed': 4, 'draft': 4, 'released to lab': 8}\n",
     "\n",
     "\n",
     "my_auth = get_key('andyprod', keyfile='~/keypairs.json')\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicwrangling"
-version = "1.2.0"
+version = "1.2.1"
 description = "Scripts and Jupyter notebooks for 4DN wrangling"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
UserContent items (e.g. HiglassViewConfig, StaticSection, ...) have uncommon statuses. One of these, `released to lab`, needs to be equivalent to `pre-release`, i.e. level = 8, otherwise it will cause an error when pre-releasing a dataset that contains such items, because the script will try to update the status with `pre-release` which is not one of the statuses available for these items.