### PR TITLE
update to notebook 16

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ------
 
 
+3.2.1
+=====
+
+* Minor update to Notebook 16_add_lab_award.ipynb to provide option to keep only alias, lab and award column in the output file.
+
+
 3.2.0
 =====
 

--- a/notebooks/useful_notebooks/16_add_lab_award.ipynb
+++ b/notebooks/useful_notebooks/16_add_lab_award.ipynb
@@ -51,21 +51,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "dd6024e6-fe67-4175-8327-a73ec4bf4c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wb = load_workbook(filename = infile)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "id": "bbd0fd41-75fe-4d37-8b89-11159a2deca4",
    "metadata": {},
    "outputs": [],
    "source": [
+    "wb = load_workbook(filename = infile)\n",
+    "\n",
     "for sheet in wb:\n",
     "    first_row = []\n",
     "    for row in sheet.iter_rows(min_row=1, max_col=sheet.max_column, max_row=1):\n",
@@ -103,14 +95,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#saving in separate file\n",
-    "wb.save(outfile)"
+    "del_other_cols = False    #Set it to True to delete all columns except alias, lab and award.\n",
+    "\n",
+    "if del_other_cols:\n",
+    "    for sheet in wb:\n",
+    "        for row in sheet.iter_rows(min_row=1, max_col=sheet.max_column, max_row=1):\n",
+    "            for cell in row:\n",
+    "                if cell.value == \"lab\":\n",
+    "                    end_col = cell.col_idx\n",
+    "        sheet.delete_cols(3, end_col - 3)\n",
+    "    wb.save(outfile)    \n",
+    "else:\n",
+    "    wb.save(outfile)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -124,7 +126,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "20a8c46b2d59997a99db768ec2ffdd239be0b4d0dbcd8c0fa58604f5ac848087"
+   }
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicwrangling"
-version = "3.2.0"
+version = "3.2.1"
 description = "Scripts and Jupyter notebooks for 4DN wrangling"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Minor update to notebook 16_add_lab_award to add an option to keep only alias, lab and award columns in the output file. Helpful when updating just the alias and lab.